### PR TITLE
Add initial unit tests for arcade drive control

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version in ThisBuild := "0.1.0-SNAPSHOT"
 
 scalaVersion in ThisBuild := "2.12.1"
 
-crossScalaVersions in ThisBuild := Seq("2.11.8", "2.12.1")
+crossScalaVersions in ThisBuild := Seq("2.12.1")
 
 coverageEnabled in ThisBuild := true
 

--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/Drive.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/Drive.scala
@@ -9,8 +9,8 @@ trait Drive {
   type DriveSignal
   type DriveVelocity
 
-  protected def driveClosedLoop[C[_]](drive: SignalLike[DriveSignal, C]): PeriodicSignal[DriveSignal]
-  protected def driveVelocityControl[C[_]](signal: SignalLike[DriveVelocity, C]): PeriodicSignal[DriveSignal]
+  protected def driveClosedLoop[C[_]](signal: SignalLike[DriveSignal, C]): PeriodicSignal[DriveSignal]
+  protected def driveVelocity[C[_]](velocity: SignalLike[DriveVelocity, C]): PeriodicSignal[DriveSignal]
 
   protected def defaultController: PeriodicSignal[DriveSignal]
 

--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/TwoSidedDrive.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/TwoSidedDrive.scala
@@ -39,7 +39,7 @@ trait TwoSidedDrive extends UnicycleDrive { self =>
   protected def driveClosedLoop[C[_]](signal: SignalLike[TwoSidedSignal, C]): PeriodicSignal[TwoSidedSignal] =
     TwoSidedControllers.velocity(signal.map(expectedVelocity))
 
-  protected def driveVelocityControl[C[_]](signal: SignalLike[TwoSidedVelocity, C]): PeriodicSignal[TwoSidedSignal] =
+  protected def driveVelocity[C[_]](signal: SignalLike[TwoSidedVelocity, C]): PeriodicSignal[TwoSidedSignal] =
     TwoSidedControllers.velocity(signal)
 
   protected val maxLeftVelocity: Velocity

--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/UnicycleDrive.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/UnicycleDrive.scala
@@ -22,7 +22,11 @@ trait UnicycleDrive extends Drive {
 
   protected val forwardControlGains: PIDFProperUnitsConfig[Velocity, Acceleration, Length, Dimensionless]
 
-  protected val turnControlGains: PIDFConfig[AngularVelocity, GenericValue[AngularVelocity], GenericDerivative[AngularVelocity], GenericIntegral[AngularVelocity], Dimensionless]
+  protected val turnControlGains: PIDFConfig[AngularVelocity,
+                                             GenericValue[AngularVelocity],
+                                             GenericDerivative[AngularVelocity],
+                                             GenericIntegral[AngularVelocity],
+                                             Dimensionless]
 
   protected val forwardVelocity: Signal[Velocity]
   protected val turnVelocity: Signal[AngularVelocity]
@@ -36,11 +40,11 @@ trait UnicycleDrive extends Drive {
   }
 
   object UnicycleControllers {
-    def forward(forwardSpeed: Signal[Dimensionless]): PeriodicSignal[DriveSignal] = {
+    def forwardOpen(forwardSpeed: Signal[Dimensionless]): PeriodicSignal[DriveSignal] = {
       toClosedDrive(forwardSpeed.map(f => UnicycleSignal(f, Percent(0))))
     }
 
-    def turn(turnSpeed: Signal[Dimensionless]): PeriodicSignal[DriveSignal] = {
+    def turnOpen(turnSpeed: Signal[Dimensionless]): PeriodicSignal[DriveSignal] = {
       toClosedDrive(turnSpeed.map(t => UnicycleSignal(Percent(0), t)))
     }
 

--- a/commons/src/test/scala/com/lynbrookrobotics/potassium/commons/drivetrain/UnicycleDriveTest.scala
+++ b/commons/src/test/scala/com/lynbrookrobotics/potassium/commons/drivetrain/UnicycleDriveTest.scala
@@ -1,0 +1,95 @@
+package com.lynbrookrobotics.potassium.commons.drivetrain
+
+import com.lynbrookrobotics.potassium.control.PIDFConfig
+import com.lynbrookrobotics.potassium.{PeriodicSignal, Signal, SignalLike}
+import org.scalatest.FunSuite
+import squants.{Each, Percent, Velocity}
+import squants.motion.{AngularVelocity, DegreesPerSecond, MetersPerSecond, MetersPerSecondSquared}
+import org.scalacheck.Prop.forAll
+import org.scalatest.prop.Checkers._
+import squants.time.{Milliseconds, Seconds}
+import com.lynbrookrobotics.potassium.units._
+import squants.space.Meters
+import com.lynbrookrobotics.potassium.units.GenericValue._
+
+class UnicycleDriveTest extends FunSuite {
+  private trait TestDrivetrain extends UnicycleDrive {
+    override type DriveSignal = UnicycleSignal
+    override type DriveVelocity = UnicycleSignal
+
+    override protected def convertUnicycleToDrive(uni: UnicycleSignal): DriveSignal = uni
+
+    override protected val controlMode: UnicycleControlMode = NoOperation
+
+    override protected def driveClosedLoop[C[_]](signal: SignalLike[DriveSignal, C]): PeriodicSignal[DriveSignal] = signal.toPeriodic
+
+    override protected def driveVelocity[C[_]](velocity: SignalLike[DriveVelocity, C]): PeriodicSignal[DriveSignal] = velocity.toPeriodic
+
+    override type Drivetrain = Nothing
+
+    var currentForwardVelocity: Velocity = MetersPerSecond(0)
+    var currentTurnVelocity: AngularVelocity = DegreesPerSecond(0)
+
+    override protected val forwardVelocity: Signal[Velocity] = Signal(currentForwardVelocity)
+    override protected val turnVelocity: Signal[AngularVelocity] = Signal(currentTurnVelocity)
+
+    override protected val maxForwardVelocity: Velocity = MetersPerSecond(10)
+    override protected val maxTurnVelocity: AngularVelocity = DegreesPerSecond(10)
+  }
+
+  test("Open forward loop produces same forward speed as input and zero turn speed") {
+    val drive = new TestDrivetrain {
+      override protected val forwardControlGains = null
+      override protected val turnControlGains = null
+    }
+
+    check(forAll { x: Double =>
+      val out = drive.UnicycleControllers.
+        forwardOpen(Signal.constant(Each(x))).
+        currentValue(Milliseconds(5))
+      out.forward.toEach == x && out.turn.toEach == 0
+    })
+  }
+
+  test("Open turn loop produces same turn speed as input and zero forward speed") {
+    val drive = new TestDrivetrain {
+      override protected val forwardControlGains = null
+      override protected val turnControlGains = null
+    }
+
+    check(forAll { x: Double =>
+      val out = drive.UnicycleControllers.
+        turnOpen(Signal.constant(Each(x))).
+        currentValue(Milliseconds(5))
+      out.turn.toEach == x && out.forward.toEach == 0
+    })
+  }
+
+  test("Closed loop with only feed-forward is essentially open loop") {
+    val drive = new TestDrivetrain {
+      override protected val forwardControlGains = PIDFConfig(
+        Percent(0) / MetersPerSecond(1),
+        Percent(0) / MetersPerSecondSquared(1),
+        Percent(0) / Meters(1),
+        Percent(100) / maxForwardVelocity
+      )
+
+      override protected val turnControlGains = PIDFConfig(
+        Percent(0) / DegreesPerSecond(1),
+        Percent(0) / (DegreesPerSecond(1).toGeneric / Seconds(1)),
+        Percent(0) / (DegreesPerSecond(1).toGeneric * Seconds(1)),
+        Percent(100) / maxTurnVelocity
+      )
+    }
+
+    check(forAll { (fwd: Double, turn: Double) =>
+      val in = Signal.constant(drive.UnicycleVelocity(MetersPerSecond(fwd), DegreesPerSecond(turn)))
+      val out = drive.UnicycleControllers.
+        velocity(in).
+        currentValue(Milliseconds(5))
+
+      (math.abs(out.forward.toEach - (fwd / 10)) / out.forward.toEach <= 0.0000001) &&
+        (math.abs(out.turn.toEach - (turn / 10)) / out.turn.toEach <= 0.0000001)
+    })
+  }
+}

--- a/control/src/main/scala/com/lynbrookrobotics/potassium/control/PIDF.scala
+++ b/control/src/main/scala/com/lynbrookrobotics/potassium/control/PIDF.scala
@@ -42,7 +42,7 @@ object PIDF {
     proportionalControl(signal, target, config.kp).
       zip(integralControl(signal.map((x, _) => ex(x)), config.ki)).
       zip(derivativeControl(signal.map((x, _) => ex(x)), config.kd)).
-      zip(feedForwardControl(signal, config.kf)).map { case ((((p, i), d), f), _) =>
+      zip(feedForwardControl(target, config.kf)).map { case ((((p, i), d), f), _) =>
       p + i + d + f
     }
   }

--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/units/GenericValues.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/units/GenericValues.scala
@@ -46,6 +46,10 @@ object GenericValue {
   implicit def toGenericValue[T <: Quantity[T]](l: T): GenericValue[T] = new GenericValue[T](l.value, l.unit)
   implicit def fromGenericValue[T <: Quantity[T]](v: GenericValue[T]): T = v.uom.apply(v.value)
 
+  implicit class ToGeneric[T <: Quantity[T]](l: T) {
+    def toGeneric: GenericValue[T] = toGenericValue(l)
+  }
+
   implicit def fromSignalLike[T <: Quantity[T]](target: PeriodicSignal[T]): PeriodicSignal[GenericValue[T]] = {
     target.map((x, _) => toGenericValue(x))
   }

--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/units/Ratio.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/units/Ratio.scala
@@ -11,4 +11,8 @@ import squants.Quantity
   */
 class Ratio[N <: Quantity[N], D <: Quantity[D]](num: N, den: D) {
   def *(value: D): N = value / den * num
+
+  override def toString: String = {
+    num.toString() + " / " + den.toString()
+  }
 }


### PR DESCRIPTION
Adds basic control tests for open-loop control and feedforward only control (basically open-loop).

Shows the importance of unit testing because this found a bug with our PIDF control method (switched sensor signal with target for feedforward)!