### PR TITLE
Only enable coverage when running unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - npm install
   - npm install jsdom
 script:
-  - 'sbt "+ testOnly * -- -l com.lynbrookrobotics.potassium.PerfTest" "coverageReport"'
+  - 'sbt "clean" "coverage" "+ testOnly * -- -l com.lynbrookrobotics.potassium.PerfTest" "coverageReport"'
   - 'sbt coverageAggregate'
 jdk: oraclejdk8
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,6 @@ scalaVersion in ThisBuild := "2.12.1"
 
 crossScalaVersions in ThisBuild := Seq("2.12.1")
 
-coverageEnabled in ThisBuild := true
-
 lazy val sharedDependencies = Def.setting(Seq(
   "org.typelevel"  %%% "squants"  % "1.0.0",
   "org.scalatest" %%% "scalatest" % "3.0.1" % Test,


### PR DESCRIPTION
This prevents publishing libraries with coverage enabled inside them

Discovered when running frc-2017 with @dtjong 