### PR TITLE
Add drivetrain hardware/props and cleanup controller method names

### DIFF
--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/Drive.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/Drive.scala
@@ -9,10 +9,18 @@ trait Drive {
   type DriveSignal
   type DriveVelocity
 
-  protected def driveClosedLoop(signal: SignalLike[DriveSignal]): PeriodicSignal[DriveSignal]
-  protected def driveVelocity(velocity: SignalLike[DriveVelocity]): PeriodicSignal[DriveSignal]
+  type DrivetrainHardware
+  type DrivetrainProperties
 
-  protected def defaultController: PeriodicSignal[DriveSignal]
+  /**
+    * Drives with the signal with closed-loop control
+    * @param signal the signal to drive with
+    * @return
+    */
+  protected def driveClosedLoop(signal: SignalLike[DriveSignal]): PeriodicSignal[DriveSignal]
+
+  protected def defaultController(implicit hardware: DrivetrainHardware,
+                                  props: DrivetrainProperties): PeriodicSignal[DriveSignal]
 
   type Drivetrain <: Component[DriveSignal]
 }

--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/TwoSidedDrive.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/TwoSidedDrive.scala
@@ -1,12 +1,37 @@
 package com.lynbrookrobotics.potassium.commons.drivetrain
 
 import com.lynbrookrobotics.potassium.clock.Clock
-import com.lynbrookrobotics.potassium.control.{PIDF, PIDFConfig, PIDFProperUnitsConfig}
+import com.lynbrookrobotics.potassium.control.{PIDF, PIDFConfig}
 import com.lynbrookrobotics.potassium.units._
 import com.lynbrookrobotics.potassium.{Component, PeriodicSignal, Signal, SignalLike}
-import squants.{Acceleration, Dimensionless, Each, Length, Time, Velocity}
+
 import squants.motion.{MetersPerSecond, MetersPerSecondSquared}
 import squants.space.Meters
+import squants.{Dimensionless, Each, Time, Velocity}
+
+trait TwoSidedDriveHardware extends UnicycleHardware {
+  val leftVelocity: Signal[Velocity]
+  val rightVelocity: Signal[Velocity]
+
+  val forwardVelocity: Signal[Velocity] =
+    leftVelocity.zip(rightVelocity).map(t => (t._1 + t._2) / 2)
+}
+
+trait TwoSidedDriveProperties extends UnicycleProperties {
+  val maxLeftVelocity: Velocity
+  val maxRightVelocity: Velocity
+  val leftControlGains: VelocityGains
+  val rightControlGains: VelocityGains
+
+  val maxForwardVelocity: Velocity = maxLeftVelocity min maxRightVelocity
+
+  val forwardControlGains: VelocityGains = PIDFConfig(
+    Each(0) / MetersPerSecond(1),
+    Each(0) / MetersPerSecondSquared(1),
+    Each(0) / Meters(1),
+    Each(1) / maxForwardVelocity
+  )
+}
 
 /**
   * A drivetrain with two side control (such as a tank drive)
@@ -18,7 +43,8 @@ trait TwoSidedDrive extends UnicycleDrive { self =>
   type DriveSignal = TwoSidedSignal
   type DriveVelocity = TwoSidedVelocity
 
-  type DrivetrainHardware
+  type DrivetrainHardware <: TwoSidedDriveHardware
+  type DrivetrainProperties <: TwoSidedDriveProperties
 
   protected implicit val clock: Clock
   protected val updatePeriod: Time
@@ -32,46 +58,45 @@ trait TwoSidedDrive extends UnicycleDrive { self =>
     )
   }
 
-  protected def expectedVelocity(drive: TwoSidedSignal): TwoSidedVelocity = {
-    TwoSidedVelocity(maxLeftVelocity * drive.left, maxRightVelocity * drive.right)
+  protected def expectedVelocity(drive: TwoSidedSignal)(implicit props: DrivetrainProperties): TwoSidedVelocity = {
+    TwoSidedVelocity(props.maxLeftVelocity * drive.left, props.maxRightVelocity * drive.right)
   }
 
-  protected def driveClosedLoop(signal: SignalLike[TwoSidedSignal]): PeriodicSignal[TwoSidedSignal] =
-    TwoSidedControllers.velocity(signal.map(expectedVelocity))
-
-  protected def driveVelocity(signal: SignalLike[TwoSidedVelocity]): PeriodicSignal[TwoSidedSignal] =
-    TwoSidedControllers.velocity(signal)
-
-  protected val maxLeftVelocity: Velocity
-  protected val maxRightVelocity: Velocity
-
-  protected val leftControlGains: PIDFProperUnitsConfig[Velocity, Acceleration, Length, Dimensionless]
-  protected val rightControlGains: PIDFProperUnitsConfig[Velocity, Acceleration, Length, Dimensionless]
-
-  // disable unicycle forward control because we already control that here
-  override protected val forwardControlGains: PIDFConfig[Velocity, Velocity, Acceleration, Length, Dimensionless] = PIDFConfig(
-    Each(0) / MetersPerSecond(1),
-    Each(0) / MetersPerSecondSquared(1),
-    Each(0) / Meters(1),
-    Each(0) / MetersPerSecond(0)
-  )
-
-  protected val leftVelocity: PeriodicSignal[Velocity]
-  protected val rightVelocity: PeriodicSignal[Velocity]
-
-  override protected val forwardVelocity: PeriodicSignal[Velocity] =
-    leftVelocity.zip(rightVelocity).map(t => (t._1 + t._2) / 2)
+  protected def driveClosedLoop(signal: SignalLike[TwoSidedSignal])
+                               (implicit hardware: DrivetrainHardware,
+                                         props: DrivetrainProperties): PeriodicSignal[TwoSidedSignal] =
+    TwoSidedControllers.closedLoopControl(signal)
 
   object TwoSidedControllers {
-    def velocity(target: SignalLike[TwoSidedVelocity]): PeriodicSignal[TwoSidedSignal] = {
-      val leftControl = PIDF.pidf(leftVelocity, target.map(_.left).toPeriodic, leftControlGains)
-      val rightControl = PIDF.pidf(rightVelocity, target.map(_.right).toPeriodic, rightControlGains)
+    def velocityControl(target: SignalLike[TwoSidedVelocity])
+                       (implicit hardware: DrivetrainHardware,
+                                 props: DrivetrainProperties): PeriodicSignal[TwoSidedSignal] = {
+      import hardware._
+      import props._
+
+      val leftControl = PIDF.pidf(
+        leftVelocity.toPeriodic,
+        target.map(_.left).toPeriodic,
+        leftControlGains
+      )
+
+      val rightControl = PIDF.pidf(
+        rightVelocity.toPeriodic,
+        target.map(_.right).toPeriodic,
+        rightControlGains
+      )
 
       leftControl.zip(rightControl).map(s => TwoSidedSignal(s._1, s._2))
     }
+
+    def closedLoopControl(signal: SignalLike[TwoSidedSignal])
+                         (implicit hardware: DrivetrainHardware,
+                                   props: DrivetrainProperties): PeriodicSignal[TwoSidedSignal] = {
+      velocityControl(signal.map(expectedVelocity))
+    }
   }
 
-  class Drivetrain(implicit hardware: DrivetrainHardware) extends Component[TwoSidedSignal](updatePeriod) {
+  class Drivetrain(implicit hardware: DrivetrainHardware, props: DrivetrainProperties) extends Component[TwoSidedSignal](updatePeriod) {
     override def defaultController: PeriodicSignal[TwoSidedSignal] = self.defaultController
 
     override def applySignal(signal: TwoSidedSignal): Unit = {

--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/package.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/package.scala
@@ -1,0 +1,17 @@
+package com.lynbrookrobotics.potassium.commons
+
+import com.lynbrookrobotics.potassium.control.{PIDFConfig, PIDFProperUnitsConfig}
+import com.lynbrookrobotics.potassium.units.{GenericDerivative, GenericIntegral, GenericValue}
+
+import squants.motion.AngularVelocity
+import squants.{Acceleration, Dimensionless, Length, Velocity}
+
+package object drivetrain {
+  type VelocityGains = PIDFProperUnitsConfig[Velocity, Acceleration, Length, Dimensionless]
+
+  type AngularVelocityGains = PIDFConfig[AngularVelocity,
+                                         GenericValue[AngularVelocity],
+                                         GenericDerivative[AngularVelocity],
+                                         GenericIntegral[AngularVelocity],
+                                         Dimensionless]
+}

--- a/commons/src/test/scala/com/lynbrookrobotics/potassium/commons/drivetrain/UnicycleDriveTest.scala
+++ b/commons/src/test/scala/com/lynbrookrobotics/potassium/commons/drivetrain/UnicycleDriveTest.scala
@@ -1,21 +1,32 @@
 package com.lynbrookrobotics.potassium.commons.drivetrain
 
 import com.lynbrookrobotics.potassium.control.PIDFConfig
-import com.lynbrookrobotics.potassium.{PeriodicSignal, Signal, SignalLike}
-import org.scalatest.FunSuite
-import squants.{Each, Percent, Velocity}
-import squants.motion.{AngularVelocity, DegreesPerSecond, MetersPerSecond, MetersPerSecondSquared}
-import org.scalacheck.Prop.forAll
-import org.scalatest.prop.Checkers._
-import squants.time.{Milliseconds, Seconds}
-import com.lynbrookrobotics.potassium.units._
-import squants.space.Meters
 import com.lynbrookrobotics.potassium.units.GenericValue._
+import com.lynbrookrobotics.potassium.units._
+import com.lynbrookrobotics.potassium.{PeriodicSignal, Signal, SignalLike}
+
+import org.scalacheck.Prop.forAll
+
+import org.scalatest.FunSuite
+import org.scalatest.prop.Checkers._
+
+import squants.motion.{AngularVelocity, DegreesPerSecond, MetersPerSecond, MetersPerSecondSquared}
+import squants.space.Meters
+import squants.time.{Milliseconds, Seconds}
+import squants.{Each, Percent, Velocity}
 
 class UnicycleDriveTest extends FunSuite {
-  private trait TestDrivetrain extends UnicycleDrive {
+  implicit val hardware: UnicycleHardware = new UnicycleHardware {
+    override val forwardVelocity: Signal[Velocity] = Signal(MetersPerSecond(0))
+    override val turnVelocity: Signal[AngularVelocity] = Signal(DegreesPerSecond(0))
+  }
+
+  private class TestDrivetrain extends UnicycleDrive {
     override type DriveSignal = UnicycleSignal
     override type DriveVelocity = UnicycleSignal
+
+    override type DrivetrainHardware = UnicycleHardware
+    override type DrivetrainProperties = UnicycleProperties
 
     override protected def convertUnicycleToDrive(uni: UnicycleSignal): DriveSignal = uni
 
@@ -23,58 +34,44 @@ class UnicycleDriveTest extends FunSuite {
 
     override protected def driveClosedLoop(signal: SignalLike[DriveSignal]): PeriodicSignal[DriveSignal] = signal.toPeriodic
 
-    override protected def driveVelocity(velocity: SignalLike[DriveVelocity]): PeriodicSignal[DriveSignal] = velocity.toPeriodic
-
     override type Drivetrain = Nothing
-
-    var currentForwardVelocity: Velocity = MetersPerSecond(0)
-    var currentTurnVelocity: AngularVelocity = DegreesPerSecond(0)
-
-    override protected val forwardVelocity: PeriodicSignal[Velocity] = Signal(currentForwardVelocity).toPeriodic
-    override protected val turnVelocity: PeriodicSignal[AngularVelocity] = Signal(currentTurnVelocity).toPeriodic
-
-    override protected val maxForwardVelocity: Velocity = MetersPerSecond(10)
-    override protected val maxTurnVelocity: AngularVelocity = DegreesPerSecond(10)
   }
 
   test("Open forward loop produces same forward speed as input and zero turn speed") {
-    val drive = new TestDrivetrain {
-      override protected val forwardControlGains = null
-      override protected val turnControlGains = null
-    }
+    val drive = new TestDrivetrain
 
     check(forAll { x: Double =>
       val out = drive.UnicycleControllers.
-        forwardOpen(Signal.constant(Each(x))).
+        openForwardClosedDrive(Signal.constant(Each(x))).
         currentValue(Milliseconds(5))
       out.forward.toEach == x && out.turn.toEach == 0
     })
   }
 
   test("Open turn loop produces same turn speed as input and zero forward speed") {
-    val drive = new TestDrivetrain {
-      override protected val forwardControlGains = null
-      override protected val turnControlGains = null
-    }
+    val drive = new TestDrivetrain
 
     check(forAll { x: Double =>
       val out = drive.UnicycleControllers.
-        turnOpen(Signal.constant(Each(x))).
+        openTurnClosedDrive(Signal.constant(Each(x))).
         currentValue(Milliseconds(5))
       out.turn.toEach == x && out.forward.toEach == 0
     })
   }
 
   test("Closed loop with only feed-forward is essentially open loop") {
-    val drive = new TestDrivetrain {
-      override protected val forwardControlGains = PIDFConfig(
+    implicit val props = new UnicycleProperties {
+      override val maxForwardVelocity: Velocity = MetersPerSecond(10)
+      override val maxTurnVelocity: AngularVelocity = DegreesPerSecond(10)
+
+      override val forwardControlGains = PIDFConfig(
         Percent(0) / MetersPerSecond(1),
         Percent(0) / MetersPerSecondSquared(1),
         Percent(0) / Meters(1),
         Percent(100) / maxForwardVelocity
       )
 
-      override protected val turnControlGains = PIDFConfig(
+      override val turnControlGains = PIDFConfig(
         Percent(0) / DegreesPerSecond(1),
         Percent(0) / (DegreesPerSecond(1).toGeneric / Seconds(1)),
         Percent(0) / (DegreesPerSecond(1).toGeneric * Seconds(1)),
@@ -82,10 +79,12 @@ class UnicycleDriveTest extends FunSuite {
       )
     }
 
+    val drive = new TestDrivetrain
+
     check(forAll { (fwd: Double, turn: Double) =>
       val in = Signal.constant(drive.UnicycleVelocity(MetersPerSecond(fwd), DegreesPerSecond(turn)))
       val out = drive.UnicycleControllers.
-        velocity(in).
+        velocityControl(in).
         currentValue(Milliseconds(5))
 
       (math.abs(out.forward.toEach - (fwd / 10)) / out.forward.toEach <= 0.0000001) &&

--- a/control/src/main/scala/com/lynbrookrobotics/potassium/control/package.scala
+++ b/control/src/main/scala/com/lynbrookrobotics/potassium/control/package.scala
@@ -5,7 +5,7 @@ import squants.time.{TimeDerivative, TimeIntegral}
 
 package object control {
   type PIDFProperUnitsConfig[S <: Quantity[S] with TimeIntegral[D] with TimeDerivative[I],
-                       D <: Quantity[D] with TimeDerivative[S],
-                       I <: Quantity[I] with TimeIntegral[S],
-                       U <: Quantity[U]] = control.PIDFConfig[S, S, D, I, U]
+                             D <: Quantity[D] with TimeDerivative[S],
+                             I <: Quantity[I] with TimeIntegral[S],
+                             U <: Quantity[U]] = control.PIDFConfig[S, S, D, I, U]
 }


### PR DESCRIPTION
Because we want to pass around hardware and properties values instead of directly depending on them (for live reloading, unit testing, etc), there are now DrivetrainHardware (for hardware interfaces) and DrivetrainProperties (for configuration) classes. We depend on these using implicit parameters to make method usage clean (subject to change???).

Also changes some controller names to clarify open-loop vs closed-loop vs velocity control.

Still need more cleanup for this, but I think this puts us in a good position to be able to start adding position and other more involved controllers. We'll probably end up landing upon better organization as we write those, anyway.