### PR TITLE
Use ImpulseEvents for polling for ContinuousEvent updates

### DIFF
--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/Signal.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/Signal.scala
@@ -1,6 +1,6 @@
 package com.lynbrookrobotics.potassium
 
-import com.lynbrookrobotics.potassium.events.{ContinuousEvent, EventPolling}
+import com.lynbrookrobotics.potassium.events.{ContinuousEvent, ImpulseEvent}
 import squants.Time
 
 /**
@@ -42,7 +42,7 @@ abstract class Signal[T] { self =>
     * @param polling the logic for polling the signal for new data
     * @return a continuous event that is active when the condition is true
     */
-  def filter(condition: T => Boolean)(implicit polling: EventPolling): ContinuousEvent = {
+  def filter(condition: T => Boolean)(implicit polling: ImpulseEvent): ContinuousEvent = {
     new ContinuousEvent(condition(get))
   }
 

--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/clock/Clock.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/clock/Clock.scala
@@ -1,5 +1,6 @@
 package com.lynbrookrobotics.potassium.clock
 
+import com.lynbrookrobotics.potassium.events.{ImpulseEvent, ImpulseEventSource}
 import squants.Time
 
 /**
@@ -22,4 +23,19 @@ trait Clock {
     * @param thunk the function to execute after the delay
     */
   def singleExecution(delay: Time)(thunk: => Unit): Unit
+
+  /**
+    * Creates an impule event that fires at a fixed rate
+    * @param period the period to fire the event at
+    * @return an event that fires at the given rate
+    */
+  def periodicEvent(period: Time): ImpulseEvent = {
+    val source = new ImpulseEventSource
+
+    apply(period) { _ =>
+      source.fire()
+    }
+
+    source.event
+  }
 }

--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/events/ContinuousEvent.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/events/ContinuousEvent.scala
@@ -1,22 +1,13 @@
 package com.lynbrookrobotics.potassium.events
 
-import com.lynbrookrobotics.potassium.clock.Clock
 import com.lynbrookrobotics.potassium.tasks.{ContinuousTask, Task}
-import squants.Time
-
-/**
-  * Contains configuration for continuous event condition polling
-  * @param clock the clock to use to periodically check the condition
-  * @param period the period to check the condition at
-  */
-case class EventPolling(clock: Clock, period: Time)
 
 /**
   * An event that has a start, running, and ending phase.
   * @param condition a boolean condition for when the event should be active
-  * @param polling the configuration for periodically checking if the event should be active
+  * @param polling the event that is called each time the event should be updated
   */
-class ContinuousEvent(condition: => Boolean)(implicit polling: EventPolling) {
+class ContinuousEvent(condition: => Boolean)(implicit polling: ImpulseEvent) {
   private val onStartSource = new ImpulseEventSource
   private val onEndSource = new ImpulseEventSource
 
@@ -33,7 +24,7 @@ class ContinuousEvent(condition: => Boolean)(implicit polling: EventPolling) {
   private var tickingCallbacks: List[() => Unit] = List.empty
   private var isRunning = false
 
-  polling.clock(polling.period) { _ =>
+  polling.foreach { () =>
     if (condition) {
       tickingCallbacks.foreach(_.apply())
 


### PR DESCRIPTION
This allows us to introduce more advanced polling mechanisms, such as waiting for new data from the driver station before updating human input events. In addition, this simplifies the interactions between impulse and continuous events, since now impulse events are used to check continuous event conditions.

https://app.asana.com/0/219272915179160/252955905579569, https://app.asana.com/0/219272915179160/250106024468351