### PR TITLE
Extrapolate look ahead points to prevent rapid turning when approaching final target way point

### DIFF
--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/MathUtilities.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/MathUtilities.scala
@@ -84,14 +84,29 @@ object MathUtilities {
     }
   }
 
-  @deprecated
   def intersectionLineCircleFurthestFromStart(segment: Segment,
                                               center: Point,
                                               radius: Length): Option[Point] = {
     val solutions = interSectionCircleLine(segment, center, radius)
     solutions.flatMap { s =>
       val (positive, negative) = s
-      if ((negative distanceTo segment.start) > (positive distanceTo segment.start)) {
+
+      implicit val Tolerance = Feet(0.001)
+      val negativeToStart = negative distanceTo segment.start
+      val positiveToStart = positive distanceTo segment.start
+
+      // Handle edge case where both solutions are equidistant from start. Then
+      // return solution closest to the endpoint of the segment
+      if (negativeToStart ~= positiveToStart) {
+        val negativeToEnd = negative distanceTo segment.end
+        val positiveToEnd = positive distanceTo segment.end
+
+        if (positiveToEnd < negativeToEnd) {
+          Some(positive)
+        } else {
+          Some(negative)
+        }
+      } else if (negativeToStart > positiveToStart) {
         Some(negative)
       } else {
         Some(positive)

--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/PurePursuitTasks.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/PurePursuitTasks.scala
@@ -25,8 +25,8 @@ trait PurePursuitTasks extends UnicycleCoreTasks {
 
   class FollowWayPoints(wayPoints: Seq[Point], tolerance: Length)
                        (implicit drive: Drivetrain,
-                        properties: Signal[UnicycleProperties],
-                        hardware: UnicycleHardware) extends FiniteTask {
+                        properties: Signal[DrivetrainProperties],
+                        hardware: DrivetrainHardware) extends FiniteTask {
     override def onStart(): Unit = {
       val initialTurnPosition = hardware.turnPosition.get
 
@@ -37,7 +37,10 @@ trait PurePursuitTasks extends UnicycleCoreTasks {
         hardware.forwardPosition
       )
 
-      val (unicycle, error) = followWayPointsController(wayPoints, position, turnPosition)
+      val (unicycle, error) = followWayPointsController(
+        wayPoints,
+        position,
+        turnPosition)
 
       drive.setController(lowerLevelOpenLoop(unicycle.withCheck { _ =>
         if (error.get.exists(_ < tolerance)) {
@@ -56,10 +59,13 @@ trait PurePursuitTasks extends UnicycleCoreTasks {
                                     position: PeriodicSignal[Point],
                                     turnPosition: Signal[Angle])
                                    (implicit drive: Drivetrain,
-                                    properties: Signal[UnicycleProperties],
-                                    hardware: UnicycleHardware) extends FiniteTask {
+                                    properties: Signal[DrivetrainProperties],
+                                    hardware: DrivetrainHardware) extends FiniteTask {
     override def onStart(): Unit = {
-      val (unicycle, error) = followWayPointsController(wayPoints, position, turnPosition)
+      val (unicycle, error) = followWayPointsController(
+        wayPoints,
+        position,
+        turnPosition)
 
       drive.setController(lowerLevelOpenLoop(unicycle.withCheck { _ =>
         if (error.get.exists(_ < tolerance)) {

--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/UnicycleCoreControllers.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/drivetrain/UnicycleCoreControllers.scala
@@ -122,4 +122,18 @@ trait UnicycleCoreControllers {
 
     (control, error)
   }
+
+  def turnPositionControl(targetAbsolute: PeriodicSignal[Angle])
+    (implicit hardware: DrivetrainHardware,
+      props: Signal[DrivetrainProperties]): (PeriodicSignal[UnicycleSignal], PeriodicSignal[Angle]) = {
+    val error = hardware.turnPosition.toPeriodic.zip(targetAbsolute).map(a => a._1 - a._2)
+
+    val control = PIDF.pid(
+      hardware.turnPosition.toPeriodic,
+      targetAbsolute,
+      props.map(_.turnPositionControlGains)
+    ).map(s => UnicycleSignal(Percent(0), s))
+
+    (control, error)
+  }
 }


### PR DESCRIPTION
Rather than restricting the look ahead point to be on the defined path, we instead extrapolate the line segments, and use the look ahead point on the extrapolated line. This fixes the bug where the robot turns 90 degrees upon reaching the target turns 90 degrees, because instead of turning toward the last point in the path, the robot turns toward an imaginary point ahead if itself.