### PR TITLE
Run all WPIClock periodic tasks in their own thread

### DIFF
--- a/frc/src/main/scala/com/lynbrookrobotics/potassium/frc/WPIClock.scala
+++ b/frc/src/main/scala/com/lynbrookrobotics/potassium/frc/WPIClock.scala
@@ -1,5 +1,7 @@
 package com.lynbrookrobotics.potassium.frc
 
+import java.util.concurrent.Semaphore
+
 import com.lynbrookrobotics.potassium.clock.Clock
 import edu.wpi.first.wpilibj.{Notifier, Utility}
 import squants.Time
@@ -8,24 +10,33 @@ import squants.time.{Microseconds, Seconds}
 object WPIClock extends Clock {
   override def apply(period: Time)(thunk: (Time) => Unit): Cancel = {
     var lastTime: Option[Time] = None
-    var running = false
+    var running = true
 
-    val notifier = new Notifier(() => {
-      if (!running) {
-        running = true
+    val semaphore = new Semaphore(1)
+    val thread = new Thread(() => {
+      while (running && !Thread.interrupted()) {
+        semaphore.acquire()
+
         val currentTime = Microseconds(Utility.getFPGATime)
         lastTime.foreach { l =>
           thunk(currentTime - l)
         }
 
         lastTime = Some(currentTime)
-        running = false
       }
     })
 
+    val notifier = new Notifier(() => {
+      semaphore.release()
+    })
+
+    thread.start()
     notifier.startPeriodic(period.to(Seconds))
 
-    () => notifier.stop()
+    () => {
+      notifier.stop()
+      running = false
+    }
   }
 
   override def singleExecution(delay: Time)(thunk: => Unit): Unit = {


### PR DESCRIPTION
Right now, there is no documentation on what thread WPILib runs Notifier tasks in, so this PR changes the implementation of setting up periodic tasks to use a separate thread with a semaphore transferring Notifier ticks to execution of the task within the thread.