### PR TITLE
Fix bugs with Simpson's integration and position calculation with Simpson's integration

### DIFF
--- a/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/cartesianPosition/XYPosition.scala
+++ b/commons/src/main/scala/com/lynbrookrobotics/potassium/commons/cartesianPosition/XYPosition.scala
@@ -8,40 +8,17 @@ import squants.space._
 object XYPosition {
   /**
     * returns signal of current xy position provided distance traveled since
-    * start of calculations and current angle
+    * start of calculations and current angle. It assumes that motion of the robot is
+    * a straight line between ticks, and then using vector addition to continually update
+    * the position
     * @param angle current trigonometric angle in about z axis (in the xy
-    *              plane), where 0 is defined at the x axis
-    * @param distanceTraveled the total distance/arclength traveled
+    *              plane), where 0 is defined at the x axis. Used as the angle of the
+    *              vector in vector addition
+    * @param distanceTraveled the total distance/arclength traveled. Used as the
+    *                         magnitude of the vectore used in vector addition
     */
   def apply(angle: Signal[Angle],
-    distanceTraveled: Signal[Length]): PeriodicSignal[Point] = {
-    val initAngle = angle.get
-    val averageAngle = angle.toPeriodic.sliding(2, initAngle).map(angles =>
-      (angles.head + angles.last) / 2D)
-
-    val initDistanceTraveled = distanceTraveled.get
-    val deltaDistance = distanceTraveled.toPeriodic.
-      sliding(2, initDistanceTraveled).map { distances =>
-      distances.last - distances.head
-    }
-
-    val origin = new Point(
-      Feet(0),
-      Feet(0)
-    )
-
-    // approximate that robot traveled in a straight line at the average
-    // angle over the course of 1 tick
-    deltaDistance.zip(averageAngle).scanLeft(origin){
-      case (acc, (distance, avrgAngle), _) =>
-        acc + new Point(
-          distance * Math.cos(avrgAngle.toRadians),
-          distance * Math.sin(avrgAngle.toRadians))
-    }
-  }
-
-  def positionWithSimpsons(angle: Signal[Angle],
-    distanceTraveled: Signal[Length]): PeriodicSignal[Point] = {
+            distanceTraveled: Signal[Length]): PeriodicSignal[Point] = {
     val initAngle = angle.get
     val averageAngle = angle.toPeriodic.sliding(2, initAngle).map(angles =>
       (angles.head + angles.last) / 2D)
@@ -51,21 +28,48 @@ object XYPosition {
       distances.last - distances.head
     }
 
-    val velocity = deltaDistance.derivative
+    val origin = Point(
+      Feet(0),
+      Feet(0))
+
+    // approximate that robot traveled in a straight line at the average
+    // angle over the course of 1 tick
+    deltaDistance.zip(averageAngle).scanLeft(origin){
+      case (acc, (distance, avrgAngle), _) =>
+        acc + Point(
+          distance * avrgAngle.cos,
+          distance * avrgAngle.sin)
+    }
+  }
+
+  /**
+    * differentiats position, then reintegrates with Simpsons integration
+    * @param angle
+    * @param distanceTraveled
+    * @return
+    */
+  def positionWithSimpsons(angle: Signal[Angle],
+                           distanceTraveled: Signal[Length]): PeriodicSignal[Point] = {
+    val initAngle = angle.get
+    val averageAngle = angle.toPeriodic.sliding(2, initAngle).map(angles =>
+      (angles.head + angles.last) / 2D)
+
+    val velocity = distanceTraveled.toPeriodic.derivative
     val velocityX = velocity.zip(averageAngle).map{v =>
       val (speed, angle) = v
-      Math.cos(angle.toRadians) * speed
+      angle.cos * speed
     }
+
     val velocityY = velocity.zip(averageAngle).map{v =>
       val (speed, angle) = v
-      Math.sin(angle.toRadians) * speed
+      angle.sin * speed
     }
 
     val xPosition = velocityX.simpsonsIntegral
     val yPosition = velocityY.simpsonsIntegral
 
     xPosition.zip(yPosition).map { pose =>
-      new Point(pose._1, pose._2)
+      Point(pose._1, pose._2)
     }
   }
 }

--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/PeriodicSignal.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/PeriodicSignal.scala
@@ -187,6 +187,7 @@ abstract class PeriodicSignal[+T] { self =>
     * Calculates the integral of the signal, producing units of
     * The integral of the signal's units. More appropriate for
     * non-linear forms of motion.
+    * See: http://mathworld.wolfram.com/SimpsonsRule.html
     */
   def simpsonsIntegral[I <: Quantity[I] with TimeIntegral[_]](implicit derivEv: T => TimeDerivative[I]): PeriodicSignal[I] = {
     // scalastyle:off
@@ -195,7 +196,7 @@ abstract class PeriodicSignal[+T] { self =>
     previousValues.scanLeft(null.asInstanceOf[I]){(acc, current3Values, dt) =>
       if (current3Values.head != null) {
         val secondVelocity = current3Values.dequeue._2.dequeue._1
-        acc + (2 * dt * current3Values.head + 2 * dt * secondVelocity * 4.0 + 2 * dt * current3Values.last) / 6
+        acc + (dt * current3Values.head + 4 * dt * secondVelocity + dt * current3Values.last) / 6
       } else {
         (current3Values.last: TimeDerivative[I]) * dt
       }

--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/units/spacialValues.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/units/spacialValues.scala
@@ -29,6 +29,14 @@ class Point(override val x: Length,
 
 object Point {
   def origin: Point = new Point(Feet(0), Feet(0))
+
+  def apply(x: Length, y: Length, z: Length): Point = {
+    new Point(x, y, z)
+  }
+
+  def apply(x: Length, y: Length): Point = {
+    new Point(x, y)
+  }
 }
 
 case class Segment(start: Point, end: Point) {

--- a/core/shared/src/test/scala/com/lynbrookrobotics/potassium/PeriodicSignalTest.scala
+++ b/core/shared/src/test/scala/com/lynbrookrobotics/potassium/PeriodicSignalTest.scala
@@ -6,7 +6,7 @@ import squants.{Dimension, Length, Quantity, UnitOfMeasure}
 import squants.electro.Volts
 import squants.motion.MetersPerSecond
 import squants.space.{Degrees, Feet, Meters}
-import squants.time.{Milliseconds, Time, TimeDerivative, TimeIntegral}
+import squants.time._
 
 class PeriodicSignalTest extends FunSuite {
   test("Converted from constant signal") {
@@ -135,12 +135,15 @@ class PeriodicSignalTest extends FunSuite {
     }
   }
 
-  test("Simpson's Integral of a certain value produces an appropriate value") {
-    val sig = Signal(MetersPerSecond(-5)).toPeriodic.simpsonsIntegral
-    (1 to 500).foreach { _ =>
+  test("Simpson's Integral of -1 from 0 to 1 is -1") {
+    implicit val tolerance = Meters(0.00000001)
+
+    val sig = Signal(MetersPerSecond(-1)).toPeriodic.simpsonsIntegral
+    (1 to (1 / Milliseconds(5).toSeconds).toInt).foreach { _ =>
       sig.currentValue(Milliseconds(5))
     }
-    assert((sig.currentValue(Milliseconds(5))- Meters(-25)).abs < Meters(0.05))
+
+    assert(sig.currentValue(Milliseconds(5)) ~= Meters(-1))
   }
 
   test("Integral of one always produces ascending values") {


### PR DESCRIPTION
Fix bug where position calculations with Simpson's integration used second derivative of position instead of first. In addition, fix bug where dt was twice as much as it should be. By coincidence, the unit test used incorrect values that showed this integration method as functioning properly.