### PR TITLE
Add ability to relativize streams against an initial value produced by them

### DIFF
--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/streams/Stream.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/streams/Stream.scala
@@ -55,6 +55,24 @@ abstract class Stream[T] { self =>
   }
 
   /**
+    * Relativizes the stream according to the given function, which takes a base value
+    * and the current value and returns the meaningful difference between them
+    * @param f the function producing a difference between the base and latest value
+    * @tparam O the type of values in the new stream
+    * @return a new stream with values relativized against the next value from this stream
+    */
+  def relativize[O](f: (T, T) => O): Stream[O] = {
+    var lastValue: Option[T] = None
+    map { v =>
+      if (lastValue.isEmpty) {
+        lastValue = Some(v)
+      }
+
+      f(lastValue.get, v)
+    }
+  }
+
+  /**
     * Merges two streams, with a value published from the resulting stream
     * whenever the parent streams have both published a new value
     * @param other the stream to merge with

--- a/core/shared/src/test/scala/com/lynbrookrobotics/potassium/streams/StreamTest.scala
+++ b/core/shared/src/test/scala/com/lynbrookrobotics/potassium/streams/StreamTest.scala
@@ -274,4 +274,29 @@ class StreamTest extends FunSuite {
 
     assert(lastValue == 4)
   }
+
+  test("Relativized stream produces correct values") {
+    val (str, pub) = Stream.manual[Int]
+
+    pub(1)
+
+    var emitted = -1
+
+    val relativized = str.relativize((b, c) => c - b)
+    relativized.foreach(emitted = _)
+
+    assert(emitted == -1)
+
+    pub(2)
+
+    assert(emitted == 0)
+
+    pub(3)
+
+    assert(emitted == 1)
+
+    pub(5)
+
+    assert(emitted == 3)
+  }
 }


### PR DESCRIPTION
Originally brought up by @Paxelord, who needed this for pure pursuit control.