### PR TITLE
Make Stream covariant to match regular collections

### DIFF
--- a/commons/src/test/scala/com/lynbrookrobotics/potassium/commons/drivetrain/PurePursuitControllerTests.scala
+++ b/commons/src/test/scala/com/lynbrookrobotics/potassium/commons/drivetrain/PurePursuitControllerTests.scala
@@ -212,7 +212,7 @@ class PurePursuitControllerTests extends FunSuite {
 
     val target = Point(Feet(1), Feet(1))
     val position = hardware.turnPosition.mapToConstant(Point(Feet(2), Feet(2)))
-    val path: Stream[(Segment, Option[Segment])] = hardware.turnPosition.mapToConstant((Segment(origin, target), None))
+    val path = hardware.turnPosition.mapToConstant((Segment(origin, target), None))
 
     val output = controllers.purePursuitControllerTurn(
       hardware.turnPosition.mapToConstant(Degrees(45)),

--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/streams/Stream.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/streams/Stream.scala
@@ -13,8 +13,6 @@ import com.lynbrookrobotics.potassium.Platform
 import scala.annotation.unchecked.uncheckedVariance
 
 abstract class Stream[+T] { self =>
-  final type Value = T
-
   val expectedPeriodicity: ExpectedPeriodicity
 
   val originTimeStream: Option[Stream[Time]]

--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/streams/Stream.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/streams/Stream.scala
@@ -9,9 +9,10 @@ import squants.time.{Time, TimeDerivative, TimeIntegral}
 import scala.collection.immutable.Queue
 import scala.ref.WeakReference
 import com.lynbrookrobotics.potassium.Platform
-import com.lynbrookrobotics.potassium.events.{ContinuousEvent, ImpulseEvent}
 
-abstract class Stream[T] { self =>
+import scala.annotation.unchecked.uncheckedVariance
+
+abstract class Stream[+T] { self =>
   final type Value = T
 
   val expectedPeriodicity: ExpectedPeriodicity
@@ -20,7 +21,7 @@ abstract class Stream[T] { self =>
 
   private[this] var listeners = Vector.empty[T => Unit]
 
-  protected def publishValue(value: T): Unit = {
+  protected def publishValue(value: T @uncheckedVariance): Unit = {
     listeners.foreach(_.apply(value))
     // TODO: more stuff maybe
   }

--- a/core/shared/src/test/scala/com/lynbrookrobotics/potassium/streams/StreamTest.scala
+++ b/core/shared/src/test/scala/com/lynbrookrobotics/potassium/streams/StreamTest.scala
@@ -12,6 +12,12 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Promise}
 
 class StreamTest extends FunSuite {
+  test("Streams can be used as a stream of a parent type of the original element type (covariance)") {
+    val origStream: Stream[None.type] = Stream.manual[None.type]._1
+
+    assertCompiles("origStream: Stream[Option[Int]]")
+  }
+
   test("Manually created stream runs callbacks appropriately") {
     val (str, pub) = Stream.manual[Int]
 


### PR DESCRIPTION
This should fix the weird typing issues we encountered earlier, such as not being able to view a stream of `None`s as a stream of `Option`s.