### PR TITLE
add getter for `lastControlSignal`

### DIFF
--- a/core/shared/src/main/scala/com/lynbrookrobotics/potassium/Component.scala
+++ b/core/shared/src/main/scala/com/lynbrookrobotics/potassium/Component.scala
@@ -21,6 +21,7 @@ abstract class Component[T] {
   private var currentControllerHandle: Option[Cancel] = None
 
   private var lastControlSignal: Option[T] = None
+  protected def getLastControlSignal(): Option[T] = lastControlSignal
 
   def shouldComponentUpdate(previousSignal: T, newSignal: T): Boolean = true
 


### PR DESCRIPTION
We may want to check the `lastControlSignal` from Component implementations to see if we accidentally output to the hardware twice within a single loop.